### PR TITLE
Fix/user config and ci issues

### DIFF
--- a/.github/workflows/molecule-ci.yml
+++ b/.github/workflows/molecule-ci.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Install dependencies
         run: |
           python3 -m pip install --upgrade pip setuptools
-          python3 -m pip install --upgrade ansible molecule molecule-docker
+          python3 -m pip install --upgrade ansible==5.9.0 molecule molecule-docker
       - name: Write license file without logging its content
         run: 'echo "$LICENSE" > license.json'
         shell: bash
@@ -18,4 +18,4 @@ jobs:
       - name: Test with molecule
         run: |
           ansible-galaxy install -r requirements.yml
-          molecule test -- -vvv
+          molecule test

--- a/.github/workflows/molecule-ci.yml
+++ b/.github/workflows/molecule-ci.yml
@@ -18,4 +18,4 @@ jobs:
       - name: Test with molecule
         run: |
           ansible-galaxy install -r requirements.yml
-          molecule test
+          molecule test -- -vvv

--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ Role Variables
 |dss_api_version| "5.1" |
 |dss_service_user| dataiku |
 |dss_service_user_home_basedir| /home |
-|dss_service_user_allowed_sudoers_group | "sudo" |
 |dss_install_dir_location| /opt/dataiku |
 |datadir| dss_data |
 |dss_node_poll_fqdn| true # If true, use ansible_fqdn else |use ansible_host |

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Role Variables
 |dss_version| "10.0.7" |
 |dss_api_version| "5.1" |
 |dss_service_user| dataiku |
+|dss_service_user_shell| "/bin/bash" |
 |dss_service_user_home_basedir| /home |
 |dss_install_dir_location| /opt/dataiku |
 |datadir| dss_data |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,7 @@ dss_base_repository_url: https://cdn.downloads.dataiku.com/public/studio
 dss_version: "10.0.7"
 dss_api_version: "5.1"
 dss_service_user: dataiku
+dss_service_user_shell: "/bin/bash"
 dss_service_user_home_basedir: /home
 dss_install_dir_location: /opt/dataiku
 dss_node_poll_fqdn: true # If true, use ansible_fqdn else use ansible_host

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,10 +5,6 @@ dss_version: "10.0.7"
 dss_api_version: "5.1"
 dss_service_user: dataiku
 dss_service_user_home_basedir: /home
-
-# Group allowed to become dss service user. Useful when connecting to the ansible host as a non-root but sudo allowed user.
-dss_service_user_allowed_sudoers_group: "sudo"
-
 dss_install_dir_location: /opt/dataiku
 dss_node_poll_fqdn: true # If true, use ansible_fqdn else use ansible_host
 dss_license_file: license.json

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -7,4 +7,3 @@
         name: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"
       vars:
         dss_version: "10.0.7"
-        dss_service_user_shell: "/bin/sh"

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -7,3 +7,4 @@
         name: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"
       vars:
         dss_version: "10.0.7"
+        dss_service_user_shell: "/bin/sh"

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -4,19 +4,19 @@ dependency:
 driver:
   name: docker
 platforms:
-  - name: instance
-    image: python:3.7.13-slim-buster
-    pre_build_image: true
+  - name: molecule-debian10
+    image: ${MOLECULE_IMAGE:-docker.io/debian:buster}
+    pre_build_image: false
 provisioner:
   name: ansible
   inventory:
     host_vars:
       instance:
-        ansible_python_interpreter: "/usr/local/bin/python3"
+        ansible_python_interpreter: "/usr/bin/python3"
 verifier:
   name: ansible
   inventory:
     host_vars:
       instance:
-        ansible_python_interpreter: "/usr/local/bin/python3"
+        ansible_python_interpreter: "/usr/bin/python3"
 

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -7,7 +7,6 @@
     datadir: "{{dss_service_user_home_basedir}}/{{dss_service_user}}/{{datadir}}"
     api_key_name: ansible
   register: dss_connection_info
-  ignore_errors: yes
   tags: [dss-config]
 
 - name: Configure LDAP settings

--- a/tasks/pre_install.yml
+++ b/tasks/pre_install.yml
@@ -46,10 +46,9 @@
   community.general.sudoers:
     name: enable-sudoer-admin-runas-dss-account
     state: present
-    group: "{{ dss_service_user_allowed_sudoers_group }}"
+    user: "{{ ansible_user_id }}"
     runas: "{{ dss_service_user }}"
     commands: ALL
-  when: dss_service_user_allowed_sudoers_group|length > 0
 
 - name: Create dss install directory
   become: true

--- a/tasks/pre_install.yml
+++ b/tasks/pre_install.yml
@@ -37,7 +37,7 @@
   user:
     name: "{{dss_service_user}}"
     home: "{{dss_service_user_home_basedir}}/{{dss_service_user}}"
-    shell: "/bin/bash"
+    shell: "{{dss_service_user_shell}}"
     state: present
   tags: [setup, dss-setup]
 

--- a/tasks/pre_install/centos.yml
+++ b/tasks/pre_install/centos.yml
@@ -12,21 +12,22 @@
 
 # Default package manager in Centos 7 is YUM
 - name: Enable EPEL Repository on CentOS 7
+  become: true
   yum:
     name: epel-release
     state: latest
-  become: True
   when: ansible_facts['os_family'] == 'RedHat' and ansible_facts ['distribution_major_version'] == '7'
 
 # Default package manager in Centos 8 is DNF
 - name: Enable EPEL Repository on CentOS 8
+  become: true
   dnf:
     name: epel-release
     state: latest
-  become: True
   when: ansible_facts['os_family'] == 'RedHat' and ansible_facts ['distribution_major_version'] == '8'
 
 - name: Installing dependencies
+  become: true
   yum:
     name: "{{ packages }}"
     state: present
@@ -41,6 +42,7 @@
       - java-1.8.0-openjdk
 
 - name: Installing CentOS 7 sepecific packages
+  become: true
   yum:
     name: "{{ packages }}"
     state: present
@@ -50,10 +52,10 @@
       - freetype 
       - libgfortran 
       - libgomp
-  become: True
   when: ansible_facts['os_family'] == 'RedHat' and ansible_facts ['distribution_major_version'] == '7'
 
 - name: Installing CentOS 8 sepecific packages
+  become: true
   yum:
     name: "{{ packages }}"
     state: present
@@ -65,5 +67,4 @@
       - freetype 
       - libgfortran 
       - libgomp
-  become: True
   when: ansible_facts['os_family'] == 'RedHat' and ansible_facts ['distribution_major_version'] == '8'

--- a/tasks/pre_install/debian.yml
+++ b/tasks/pre_install/debian.yml
@@ -5,6 +5,7 @@
   apt:
     name: "{{ packages }}"
     state: present
+    update_cache: yes
   vars:
     packages:
       - acl

--- a/tasks/pre_install/debian.yml
+++ b/tasks/pre_install/debian.yml
@@ -1,6 +1,7 @@
 ---
 
 - name: Installing dependencies
+  become: true
   apt:
     name: "{{ packages }}"
     state: present
@@ -21,6 +22,7 @@
       - libgomp1
 
 - name: Installing Debian 10 specific packages
+  become: true
   apt:
     name: "{{ packages }}"
     state: present
@@ -30,20 +32,20 @@
       - python3-distutils
       - python3-pip
       - python3-setuptools
-  become: True
   when: ansible_facts['os_family'] == 'Debian' and ansible_facts ['distribution_major_version'] == '10'
 
 - name: Installing Ubuntu 16.04 specific packages
+  become: true
   apt:
     name: "{{ packages }}"
     state: present
   vars:
     packages:
       - python3.6
-  become: True
   when: ansible_facts['os_family'] == 'Ubuntu' and ansible_facts ['distribution_major_version'] == '16.04'
 
 - name: Installing Ubuntu 18.04 specific packages
+  become: true
   apt:
     name: "{{ packages }}"
     state: present
@@ -51,15 +53,14 @@
     packages:
       - python3.6
       - python3-distutils
-  become: True
   when: ansible_facts['os_family'] == 'Ubuntu' and ansible_facts ['distribution_major_version'] == '18.04'
 
 - name: Installing Ubuntu 20.04 specific packages
+  become: true
   apt:
     name: "{{ packages }}"
     state: present
   vars:
     packages:
       - python3.7
-  become: True
   when: ansible_facts['os_family'] == 'Ubuntu' and ansible_facts ['distribution_major_version'] == '20.04'

--- a/tasks/pre_install/debian.yml
+++ b/tasks/pre_install/debian.yml
@@ -17,7 +17,7 @@
       - unzip
       - zip
       - default-jre-headless
-      - python2.7 
+      - python2.7
       - libpython2.7 
       - libfreetype6 
       - libgomp1


### PR DESCRIPTION
- Added missing become:true when installing dependencies
- Reordered statements to make become: true more visible
- Reverted sudo permissions to allow non-root user to become dataiku service user
- Variabilized dss service user shell
- Forced ansible==5.9.0 to get rid of **dataiku-ansible-modules** python2 issue in CI environment
- Changed CI base image to **debian:buster** to reflect target environment and avoid python conflicts
- Update APT cache before trying to install new packages