### PR TITLE
Corrected spark exec config deployment

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,7 +26,85 @@ k8s_executionconfigs: []
 configure_spark: true
 dss_hadoop_package: "dataiku-dss-hadoop-standalone-libs-generic-hadoop3-10.0.7.tar.gz"
 dss_spark_package: "dataiku-dss-spark-standalone-10.0.7-3.1.2-generic-hadoop3.tar.gz"
-spark_executionconfigs: []
+spark_executionconfigs:
+  - name: default
+    description: |- 
+      This default configuration sets a few parameters that are suitable for a wide range of use cases.
+      Importantly in order to work in all circumstances it does not set the spark master configuration.
+      It will thus use the master defined by your default Spark configuration.
+      This may lead Spark jobs to execute locally without using your cluster. You may need for example to add spark.master\u003dyarn-client
+    conf:
+      - key: spark.executor.memory
+        value: 2400m
+        isFinal: false
+        secret: false
+      - key: spark.sql.shuffle.partitions
+        value: 40
+        isFinal: false
+        secret: false
+      - key: spark.yarn.executor.memoryOverhead
+        value: 600
+        isFinal: false
+        secret: false
+      - key: spark.port.maxRetries
+        value: 200
+        isFinal: false
+        secret: false
+  - name: sample-yarn-config
+    description: |- 
+      This sample configuration shows a possible set of parameters for running DSS Spark jobs on YARN.
+      These settings are suitable for a small cluster.
+      You will need to tune spark.executor.instances spark.executor.cores and memory settings based on the size of your YARN cluster.
+    conf:
+      - key: spark.master
+        value: yarn-client
+        isFinal: false
+        secret: false
+      - key: spark.executor.memory
+        value: 4g
+        isFinal: false
+        secret: false
+      - key: spark.executor.instances
+        value: 4
+        isFinal: false
+        secret: false
+      - key: spark.executor.cores
+        value: 2
+        isFinal: false
+        secret: false
+      - key: spark.sql.shuffle.partitions
+        value: 40
+        isFinal: false
+        secret: false
+      - key: spark.yarn.executor.memoryOverhead
+        value: 1200
+        isFinal: false
+        secret: false
+      - key: spark.port.maxRetries
+        value: 200
+        isFinal: false
+        secret: false      
+  - name: sample-local-config
+    description: |-
+      This sample configuration shows a possible set of parameters for running DSS Spark jobs locally (non distributed).
+      This can be useful for testing on small jobs as local Spark jobs start faster than YARN ones but is not suitable for production usage.
+    conf:
+      - key: spark.master
+        value: local[4]
+        isFinal: false
+        secret: false  
+      - key: spark.driver.memory
+        value: 3g
+        isFinal: false
+        secret: false
+      - key: spark.sql.shuffle.partitions
+        value: 40
+        isFinal: false
+        secret: false
+      - key: spark.port.maxRetries
+        value: 200
+        isFinal: false
+        secret: false  
 
 # Optional : add LDAP login capability
 configure_ldap_settings: "false"

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -49,14 +49,6 @@
     settings:
       sparkSettings:
         sparkEnabled: true
-  tags: [dss-config, molecule-idempotence-notest]
-
-- name: Enable spark on kubernetes support in DSS settings when both spark and kubernetes are enabled
-  when: configure_spark and configure_k8s
-  dss_general_settings:
-    connect_to: "{{ dss_connection_info }}"
-    settings:
-      sparkSettings:
         executionConfigs: "{{ spark_executionconfigs }}"
   tags: [dss-config, molecule-idempotence-notest]
 


### PR DESCRIPTION
Role default execution configs for spark now mirror DSS default spark configuration Spark configuration does not depend on K8S configuration anymore