### PR TITLE
Added OIDC SSO support, tweaked LDAP authentication, disabled handlers when testing with molecule

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,9 @@ spark_executionconfigs:
 | Variable | Default value |
 |----------|-------------|
 |configure_ldap_settings| false |
+
+| Variable | Sample value |
+|----------|-------------|
 |ldap_url| "ldap://ldap.internal.example.com/dc=example,dc=com"|
 |ldap_binddn| "uid=readonly,ou=users,dc=example,dc=com"
 |ldap_bindpassword: "" |
@@ -294,6 +297,27 @@ spark_executionconfigs:
 |ldap_groupnameattribute| "cn" |
 |ldap_groupprofiles| [] |
 |ldap_authorizedgroups| "dss-users" |
+
+### Optional variables for enabling OpenID Connect (OIDC) SSO authentication
+Configure `configure_oidc_sso: true` to enable OpenID Connect SSO.
+| Variable | Default value |
+|----------|-------------|
+|configure_oidc_sso| false |
+
+The following table shows an example of OIDC SSO configuration with Google IDP. Change the default values to match your IDP configuration.
+
+Remapping rules are not supported by this role.
+
+| Variable | Sample value |
+|----------|-------------|
+|oidc_clientid| test |
+|oidc_clientsecret| test |
+|oidc_scope| 'openid profile email' |
+|oidc_issuer| https://accounts.google.com |
+|oidc_authorizationendpoint| https://accounts.google.com/o/oauth2/v2/auth |
+|oidc_tokenendpoint| https://oauth2.googleapis.com/token |
+|oidc_jwksuri| https://www.googleapis.com/oauth2/v3/certs |
+|oidc_claimkeyidentifier| email_verified |
 
 
 ### Optional variables for enabling User Isolation Framework (UIF)
@@ -411,6 +435,16 @@ Sample DSS deployment playbook
         ldap_groupprofiles: []
         ldap_authorizedgroups: "dss-users"
         
+        configure_oidc_sso: true
+        oidc_clientid: test
+        oidc_clientsecret: test
+        oidc_scope: 'openid profile email'
+        oidc_issuer: https://accounts.google.com
+        oidc_authorizationendpoint: https://accounts.google.com/o/oauth2/v2/auth
+        oidc_tokenendpoint: https://oauth2.googleapis.com/token
+        oidc_jwksuri: https://www.googleapis.com/oauth2/v3/certs
+        oidc_claimkeyidentifier: email_verified
+
         configure_uif: true
         uif_users:
           userA:

--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ spark_executionconfigs:
 ### Optional variables for enabling LDAP authentication
 | Variable | Default value |
 |----------|-------------|
-|configure_ldap_settings:| "false" |
+|configure_ldap_settings| false |
 |ldap_url| "ldap://ldap.internal.example.com/dc=example,dc=com"|
 |ldap_binddn| "uid=readonly,ou=users,dc=example,dc=com"
 |ldap_bindpassword: "" |
@@ -395,7 +395,7 @@ Sample DSS deployment playbook
         dss_hadoop_package: "dataiku-dss-hadoop-standalone-libs-generic-hadoop3-11.1.1.tar.gz"
         dss_spark_package: "dataiku-dss-spark-standalone-11.1.1-3.2.1-generic-hadoop3.tar.gz"
 
-        configure_ldap_settings: "true"
+        configure_ldap_settings: true
         ldap_url: "ldap://ldap.internal.example.com/dc=example,dc=com"
         ldap_binddn: "uid=readonly,ou=users,dc=example,dc=com"
         ldap_bindpassword: ""

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -108,24 +108,14 @@ spark_executionconfigs:
         isFinal: false
         secret: false  
 
-# Optional : add LDAP login capability
+# Optional : Activate LDAP authentication
 configure_ldap_settings: "false"
-ldap_url: "ldap://ldap.internal.example.com/dc=example,dc=com"
-ldap_binddn: "uid=readonly,ou=users,dc=example,dc=com"
-ldap_bindpassword: ""
-ldap_usetls: true
-ldap_autoimportusers: true
-ldap_userfilter: "(&(objectClass=posixAccount)(uid={USERNAME}))"
-ldap_defaultuserprofile: "READER"
-ldap_displaynameattribute: "cn"
-ldap_emailattribute: "mail"
-ldap_enablegroups: true
-ldap_groupfilter: "(&(objectClass=posixGroup)(memberUid={USERDN}))"
-ldap_groupnameattribute: "cn"
-ldap_groupprofiles: []
-ldap_authorizedgroups: "dss-users"
 
-# Optional : activate User Isolation Framework (UIF)
+# Optional : OpenID Connect (OIDC) Single Sign-On authentication
+configure_oidc_sso: false
+oidc_scope: 'openid email'
+
+# Optional : Activate User Isolation Framework (UIF)
 configure_uif: false
 uif_users: {}
 uif_userrules: []

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -109,7 +109,7 @@ spark_executionconfigs:
         secret: false  
 
 # Optional : Activate LDAP authentication
-configure_ldap_settings: "false"
+configure_ldap_settings: false
 
 # Optional : OpenID Connect (OIDC) Single Sign-On authentication
 configure_oidc_sso: false

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,7 +4,7 @@
 - name: Reboot server
   become: true
   ansible.builtin.reboot:
-  tags: [setup]
+  tags: [setup, molecule-notest]
 
 - name: Regenerate DSS config
   become: true

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,7 +4,7 @@
 - name: Reboot server
   become: true
   ansible.builtin.reboot:
-  tags: [setup, molecule-notest]
+  when: (skip_handlers is undefined) or (not skip_handlers)
 
 - name: Regenerate DSS config
   become: true
@@ -16,3 +16,4 @@
   ansible.builtin.service:
     name: "dataiku.{{ dss_datadir }}"
     state: restarted
+  when: (skip_handlers is undefined) or (not skip_handlers)

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -7,7 +7,7 @@
     dss_jek_xmx: 2g
     dss_fek_xmx: 2g
     
-    configure_ldap_settings: "true"
+    configure_ldap_settings: true
     ldap_url: "ldap://ldap.internal.example.com/dc=example,dc=com"
     ldap_binddn: "uid=readonly,ou=users,dc=example,dc=com"
     ldap_bindpassword: ""

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -2,6 +2,7 @@
 - name: Converge
   hosts: all
   vars:
+    skip_handlers: true
     dss_backend_xmx: 2g
     dss_jek_xmx: 2g
     dss_fek_xmx: 2g

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -5,7 +5,33 @@
     dss_backend_xmx: 2g
     dss_jek_xmx: 2g
     dss_fek_xmx: 2g
+    
     configure_ldap_settings: "true"
+    ldap_url: "ldap://ldap.internal.example.com/dc=example,dc=com"
+    ldap_binddn: "uid=readonly,ou=users,dc=example,dc=com"
+    ldap_bindpassword: ""
+    ldap_usetls: true
+    ldap_autoimportusers: true
+    ldap_userfilter: "(&(objectClass=posixAccount)(uid={USERNAME}))"
+    ldap_defaultuserprofile: "READER"
+    ldap_displaynameattribute: "cn"
+    ldap_emailattribute: "mail"
+    ldap_enablegroups: true
+    ldap_groupfilter: "(&(objectClass=posixGroup)(memberUid={USERDN}))"
+    ldap_groupnameattribute: "cn"
+    ldap_groupprofiles: []
+    ldap_authorizedgroups: "dss-users"
+
+    configure_oidc_sso: true
+    oidc_clientid: test
+    oidc_clientsecret: test
+    oidc_scope: 'openid profile email'
+    oidc_issuer: https://accounts.google.com
+    oidc_authorizationendpoint: https://accounts.google.com/o/oauth2/v2/auth
+    oidc_tokenendpoint: https://oauth2.googleapis.com/token
+    oidc_jwksuri: https://www.googleapis.com/oauth2/v3/certs
+    oidc_claimkeyidentifier: email_verified
+
     configure_spark: true
     spark_executionconfigs:
       - name": SparkOnKubernetes

--- a/tasks/authentication.yml
+++ b/tasks/authentication.yml
@@ -1,5 +1,5 @@
 - name: Configure LDAP settings
-  when: configure_ldap_settings|bool
+  when: configure_ldap_settings
   dss_general_settings:
     connect_to: "{{ dss_connection_info }}"
     settings:

--- a/tasks/authentication.yml
+++ b/tasks/authentication.yml
@@ -1,0 +1,50 @@
+- name: Configure LDAP settings
+  when: configure_ldap_settings|bool
+  dss_general_settings:
+    connect_to: "{{ dss_connection_info }}"
+    settings:
+      ldapSettings:
+        enabled: true
+        url: "{{ ldap_url }}"
+        bindDN: "{{ ldap_binddn }}"
+        bindPassword: "{{ ldap_bindpassword }}"
+        useTls: "{{ ldap_usetls }}"
+        autoImportUsers: "{{ ldap_autoimportusers }}"
+        userFilter: "{{ ldap_userfilter }}"
+        defaultUserProfile: "{{ ldap_defaultuserprofile }}"
+        displayNameAttribute: "{{ ldap_displaynameattribute }}"
+        emailAttribute: "{{ ldap_emailattribute }}"
+        enableGroups: "{{ ldap_enablegroups }}"
+        groupFilter: "{{ ldap_groupfilter }}"
+        groupNameAttribute: "{{ ldap_groupnameattribute }}"
+        groupProfiles: "{{ ldap_groupprofiles }}"
+        authorizedGroups: "{{ ldap_authorizedgroups }}"
+  register: ldap_settings
+  changed_when: "'MODIFIED' in ldap_settings.message"
+  failed_when: ldap_settings.failed and ("'Your license does not allow you to enable LDAP authentication' not in ldap_settings.msg")
+  ignore_errors: yes
+  tags: [dss-authentication, molecule-idempotence-notest]
+
+- name: Configure OIDC SSO settings
+  when: configure_oidc_sso|bool
+  dss_general_settings:
+    connect_to: "{{ dss_connection_info }}"
+    settings:
+      ssoSettings:
+        enabled: "{{ configure_oidc_sso }}"
+        protocol: OPENID
+        remappingRu1es: []
+        openIDParams:
+            clientId: "{{ oidc_clientid }}"
+            clientSecret: "{{ oidc_clientsecret }}"
+            scope: "{{ oidc_scope }}"
+            issuer: "{{ oidc_issuer }}"
+            authorizationEndpoint: "{{ oidc_authorizationendpoint }}"
+            tokenEndpoint: "{{ oidc_tokenendpoint }}"
+            jwksUri: "{{ oidc_jwksuri }}"
+            claimKeyIdentifier: "{{ oidc_claimkeyidentifier }}"
+            useGlobalProxy: true
+            tokenEndpointAuthMethod: CLIENT_SECRET_BASIC
+  register: oidc_sso_settings
+  changed_when: "'MODIFIED' in oidc_sso_settings.message"
+  tags: [dss-authentication, molecule-idempotence-notest]

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -9,33 +9,6 @@
   register: dss_connection_info
   tags: [dss-config]
 
-- name: Configure LDAP settings
-  when: configure_ldap_settings|bool
-  dss_general_settings:
-    connect_to: "{{ dss_connection_info }}"
-    settings:
-      ldapSettings:
-        enabled: true
-        url: "{{ ldap_url }}"
-        bindDN: "{{ ldap_binddn }}"
-        bindPassword: "{{ ldap_bindpassword }}"
-        useTls: "{{ ldap_usetls }}"
-        autoImportUsers: "{{ ldap_autoimportusers }}"
-        userFilter: "{{ ldap_userfilter }}"
-        defaultUserProfile: "{{ ldap_defaultuserprofile }}"
-        displayNameAttribute: "{{ ldap_displaynameattribute }}"
-        emailAttribute: "{{ ldap_emailattribute }}"
-        enableGroups: "{{ ldap_enablegroups }}"
-        groupFilter: "{{ ldap_groupfilter }}"
-        groupNameAttribute: "{{ ldap_groupnameattribute }}"
-        groupProfiles: "{{ ldap_groupprofiles }}"
-        authorizedGroups: "{{ ldap_authorizedgroups }}"
-  register: ldap_settings
-  changed_when: "'MODIFIED' in ldap_settings.message"
-  failed_when: ldap_settings.failed and ("'Your license does not allow you to enable LDAP authentication' not in ldap_settings.msg")
-  ignore_errors: yes
-  tags: [dss-config, molecule-idempotence-notest]
-
 - name: Configure containerized execution on Kubernetes in DSS settings
   when: configure_k8s
   dss_general_settings:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,5 +29,9 @@
 - name: CONGIGURE DSS
   ansible.builtin.import_tasks: config.yml
 
+- name: CONGIGURE AUTHENTICATION
+  ansible.builtin.import_tasks: authentication.yml
+  tags: [dss-authentication]
+
 - name: DOWNLOAD AND LOAD DOCKER_IMAGES
   ansible.builtin.import_tasks: docker_images.yml

--- a/tasks/pre_install.yml
+++ b/tasks/pre_install.yml
@@ -18,6 +18,7 @@
 
 - name: Flush handlers to reboot after disabling SELinux if needed
   ansible.builtin.meta: flush_handlers
+  tags: [molecule-notest]
 
 - name: Increase system limits as required by DSS
   become: true

--- a/tasks/pre_install/centos.yml
+++ b/tasks/pre_install/centos.yml
@@ -94,4 +94,4 @@
   register: selinuxdisabled
   notify:
     - Reboot server
-  tags: [setup, molecule-notest]
+  tags: [setup]

--- a/tasks/pre_install/debian.yml
+++ b/tasks/pre_install/debian.yml
@@ -97,4 +97,4 @@
   register: selinuxdisabled
   notify:
     - Reboot server
-  tags: [setup, molecule-notest]
+  tags: [setup]


### PR DESCRIPTION
- Added OIDC SSO support with documentation
- Removed LDAP authentication sample values from role default and moved them into molecule converge play
- BREAKING CHANGE : Changed **configure_ldap_settings** type to boolean
- Disabled handlers when testing with molecule to avoid restart DSS or restart server issues. Handlers are now disabled with a when statement