### PR TITLE
Added tmp_dest to handle cases when /tmp partition is too small

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,13 +67,13 @@ Default values are applied by DSS installer for memory parameter not configured 
 |configure_k8s| false |
 |k8s_executionconfigs| [] |
 |download_dss_docker_images| false |
-|download_dss_docker_images_url_tmp_dest | |
+|download_dss_docker_images_url_tmp_directory | |
 |download_dss_docker_images_url| `{{ dss_base_repository_url }}/{{ dss_version }}/container-images/dataiku-dss-ALL-base_dss-{{ dss_version }}-r-py3.6.tar.gz` |
 
 
 The **k8s_executionconfigs** is an array which **can contain multiple containerized execution configurations** to match different business scenarios. Different kubernetes quotas can be allowed depending on user permissions, cuda ressources access can be limited to the data-scientist group, several base image can be offered to match business needs, ... 
 
-DSS docker bases images can be automatically downloaded as an archive from a web URL by configuring `download_dss_docker_images: true`. Use `download_dss_docker_images_url_tmp_dest: /local/tmp` to configure a custom ansible tmp directory if the  `/tmp`partition of the server is too small to download the 4.5G docker images archive. The `download_dss_docker_images_url` download URL is configured to use the Dataiku public CDN by default, but can be changed if needed. **DSS version must be set in the docker archive file name to make this role able to check consistency between DSS version and DSS docker images version**
+DSS docker bases images can be automatically downloaded as an archive from a web URL by configuring `download_dss_docker_images: true`. Use `download_dss_docker_images_url_tmp_directory: /local/tmp` to configure a custom ansible tmp directory if the  `/tmp`partition of the server is too small to download the 4.5G docker images archive. The `download_dss_docker_images_url` download URL is configured to use the Dataiku public CDN by default, but can be changed if needed. **DSS version must be set in the docker archive file name to make this role able to check consistency between DSS version and DSS docker images version**
 
 A configuration example is provided below with **two kubernetes execution configs**. Please make sure to replace sample **repositoryURL**, **baseImage**, and set a valid kubernetes namespace when using this sample.
 ```

--- a/README.md
+++ b/README.md
@@ -67,12 +67,13 @@ Default values are applied by DSS installer for memory parameter not configured 
 |configure_k8s| false |
 |k8s_executionconfigs| [] |
 |download_dss_docker_images| false |
+|download_dss_docker_images_url_tmp_dest | |
 |download_dss_docker_images_url| `{{ dss_base_repository_url }}/{{ dss_version }}/container-images/dataiku-dss-ALL-base_dss-{{ dss_version }}-r-py3.6.tar.gz` |
 
 
 The **k8s_executionconfigs** is an array which **can contain multiple containerized execution configurations** to match different business scenarios. Different kubernetes quotas can be allowed depending on user permissions, cuda ressources access can be limited to the data-scientist group, several base image can be offered to match business needs, ... 
 
-DSS docker bases images can be automatically downloaded as an archive from a web URL by configuring `download_dss_docker_images: true`. The `download_dss_docker_images_url` download URL is configured to use the Dataiku public CDN by default, but can be changed if needed. **DSS version must be set in the docker archive file name to make this role able to check consistency between DSS version and DSS docker images version**
+DSS docker bases images can be automatically downloaded as an archive from a web URL by configuring `download_dss_docker_images: true`. Use `download_dss_docker_images_url_tmp_dest: /local/tmp` to configure a custom ansible tmp directory if the  `/tmp`partition of the server is too small to download the 4.5G docker images archive. The `download_dss_docker_images_url` download URL is configured to use the Dataiku public CDN by default, but can be changed if needed. **DSS version must be set in the docker archive file name to make this role able to check consistency between DSS version and DSS docker images version**
 
 A configuration example is provided below with **two kubernetes execution configs**. Please make sure to replace sample **repositoryURL**, **baseImage**, and set a valid kubernetes namespace when using this sample.
 ```

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -52,6 +52,7 @@
           dockerTLSVerify: false
     configure_k8s: true
     download_dss_docker_images: true
+    download_dss_docker_images_url_tmp_directory: "{{ dss_service_user_home_basedir }}/{{ dss_service_user }}/.tmp"
     k8s_executionconfigs:
       - name: test1
         type: KUBERNETES

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -37,6 +37,7 @@ provisioner:
   log: True
   env:
     ansible_python_interpreter: "/usr/bin/python3"
+    DOCKER_TIMEOUT: 240
 verifier:
   name: ansible
   env:

--- a/tasks/docker_images.yml
+++ b/tasks/docker_images.yml
@@ -11,12 +11,22 @@
   when: download_dss_docker_images 
   tags: [docker-images]
 
+- name: Create temporary download directory if it does not exist
+  become: true
+  become_user: "{{ dss_service_user }}"
+  ansible.builtin.file:
+    path: "{{ download_dss_docker_images_url_tmp_directory }}"
+    state: directory
+    mode: '0755'
+ when: download_dss_docker_images and (download_dss_docker_images_url_tmp_directory is defined)
+ tags: [docker-images]
+
 - name: Download base images archive provided by Dataiku
   become: true
   become_user: "{{ dss_service_user }}"
   ansible.builtin.get_url:
     url: "{{ download_dss_docker_images_url }}"
-    tmp_dest: "{{ download_dss_docker_images_url_tmp_dest | default(omit) }}"
+    tmp_dest: "{{ download_dss_docker_images_url_tmp_directory | default(omit) }}"
     dest: "{{ dss_install_dir_location }}/dataiku-dss-ALL-base_dss-{{ dss_version }}-r-py3.6.tar.gz"
     mode: '644'
   register: downloaded_images_archive

--- a/tasks/docker_images.yml
+++ b/tasks/docker_images.yml
@@ -27,7 +27,7 @@
   become: true
   community.docker.docker_image_load:
     path: "{{ dss_install_dir_location }}/dataiku-dss-ALL-base_dss-{{ dss_version }}-r-py3.6.tar.gz"
-    timeout: 120
+    timeout: 240
   register: loaded_images
   when: downloaded_images_archive.changed
-  tags: [docker-images]
+  tags: [docker-images, molecule-notest]

--- a/tasks/docker_images.yml
+++ b/tasks/docker_images.yml
@@ -16,6 +16,7 @@
   become_user: "{{ dss_service_user }}"
   ansible.builtin.get_url:
     url: "{{ download_dss_docker_images_url }}"
+    tmp_dest: "{{ download_dss_docker_images_url_tmp_dest if download_dss_docker_images_url_tmp_dest is defined else ansible_remote_tmp }}"
     dest: "{{ dss_install_dir_location }}/dataiku-dss-ALL-base_dss-{{ dss_version }}-r-py3.6.tar.gz"
     mode: '644'
   register: downloaded_images_archive

--- a/tasks/docker_images.yml
+++ b/tasks/docker_images.yml
@@ -18,8 +18,8 @@
     path: "{{ download_dss_docker_images_url_tmp_directory }}"
     state: directory
     mode: '0755'
- when: download_dss_docker_images and (download_dss_docker_images_url_tmp_directory is defined)
- tags: [docker-images]
+  when: download_dss_docker_images and (download_dss_docker_images_url_tmp_directory is defined)
+  tags: [docker-images]
 
 - name: Download base images archive provided by Dataiku
   become: true

--- a/tasks/docker_images.yml
+++ b/tasks/docker_images.yml
@@ -16,7 +16,7 @@
   become_user: "{{ dss_service_user }}"
   ansible.builtin.get_url:
     url: "{{ download_dss_docker_images_url }}"
-    tmp_dest: "{{ download_dss_docker_images_url_tmp_dest if download_dss_docker_images_url_tmp_dest is defined else ansible_remote_tmp }}"
+    tmp_dest: "{{ download_dss_docker_images_url_tmp_dest | default(omit) }}"
     dest: "{{ dss_install_dir_location }}/dataiku-dss-ALL-base_dss-{{ dss_version }}-r-py3.6.tar.gz"
     mode: '644'
   register: downloaded_images_archive


### PR DESCRIPTION
- Added tmp_dest to handle cases when /tmp partition is too small
- Increased timeout to avoid random github workflow errors